### PR TITLE
Apply pending migrations and create DB if not exists

### DIFF
--- a/api/WebApi/Program.cs
+++ b/api/WebApi/Program.cs
@@ -42,6 +42,13 @@ if (app.Environment.IsDevelopment())
     app.UseSwaggerUI();
 }
 
+// Apply pending migrations and create the database if it doesn't exist
+using (var scope = app.Services.CreateScope())
+{
+    var dbContext = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+    dbContext.Database.Migrate();
+}
+
 app.UseSwagger();
 app.UseSwaggerUI();
 // Configure CORS


### PR DESCRIPTION
Added a block in `Program.cs` to ensure any pending database migrations are applied and the database is created if it doesn't already exist. This is done by creating a service scope, retrieving the `ApplicationDbContext` service, and calling the `Migrate` method on the database context. This block is added right after the Swagger setup.