### PR TITLE
Update database connection string in appsettings.json

### DIFF
--- a/api/WebApi/appsettings.json
+++ b/api/WebApi/appsettings.json
@@ -8,6 +8,7 @@
   "AllowedHosts": "*",
   "ConnectionStrings": {
     //"DefaultConnection": "Server=localhost;database=ketodb;user=root"
-    "DefaultConnection": "Server=host.docker.internal;Port=3306;database=ketodb;user=root"
+    //"DefaultConnection": "Server=host.docker.internal;Port=3306;database=ketodb;user=root",
+    "DefaultConnection": "Server=172.17.0.1;Port=3306;Database=ketodb;User Id=root;Password=simple;"
   }
 }


### PR DESCRIPTION
Commented out the old connection string pointing to host.docker.internal:3306. Added a new connection string pointing to 172.17.0.1:3306 with database name 'ketodb', user 'root', and password 'simple'.